### PR TITLE
Update Swift 2.2 snapshot URL

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -12,8 +12,8 @@ url_to_dependency_map:
 dependencies:
   - name: swift
     version: 2.2
-    uri: https://swift.org/builds/ubuntu1404/swift-2.2-SNAPSHOT-2015-12-01-b/swift-2.2-SNAPSHOT-2015-12-01-b-ubuntu14.04.tar.gz
-    md5: a93f52921c491b747cad256904c8742f
+    uri: https://swift.org/builds/ubuntu1404/swift-2.2-SNAPSHOT-2015-12-10-a/swift-2.2-SNAPSHOT-2015-12-10-a-ubuntu14.04.tar.gz
+    md5: 169a8d3f1bbf489f33bb0628a9638036
     cf_stacks:
       - cflinuxfs2
   - name: clang


### PR DESCRIPTION
Apple has posted a new snapshot that includes some nice fixes, especially for the Swift Package Manager.

Separately from this, we should consider how we want to manage the versioning of the Swift dependency during this period when there are frequent updates. This updated snapshot will still be considered version 2.2 by the compile script, so an existing app's build cache won't notice the update.
